### PR TITLE
Change Browser Log Collection Method from Bundle to NPM

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,14 +15,15 @@
 
 
 
-<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-us.js"></script>
-    <script>
-      window.DD_LOGS && DD_LOGS.init({
-        clientToken: 'pub587c7197e63cd75a70f061ad7913676b',
-        forwardErrorsToLogs: true,
-        sampleRate: 100
-      });
-    </script>
+<script> 
+  import { datadogLogs } from '@datadog/browser-logs'
+  
+  datadogLogs.init({ 
+    clientToken: 'pub587c7197e63cd75a70f061ad7913676b', 
+    datacenter: 'us', 
+    forwardErrorsToLogs: true
+  }) 
+</script>
 
 
 


### PR DESCRIPTION
Changed the Browser Log Collection method: https://docs.datadoghq.com/logs/log_collection/javascript/?tab=us#setup 

This probably won't work because [@datadog/browser-logs](https://www.npmjs.com/package/@datadog/browser-logs) needs to be added to your package.json file.